### PR TITLE
Feature/ffmpeg-static-build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
 [env]
 # Align with Homebrew FFmpeg builds to avoid macOS 14→15 linker warnings.
 MACOSX_DEPLOYMENT_TARGET = "15.0"
+# Use paths relative to the workspace root; Cargo will expand them to absolute before passing to build scripts.
+FFMPEG_DIR = { value = "target/ffmpeg-min", relative = true }
+PKG_CONFIG_PATH = { value = "target/ffmpeg-min/lib/pkgconfig", relative = true }

--- a/.github/workflows/macos-ui-ci.yml
+++ b/.github/workflows/macos-ui-ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: ./scripts/build-ffmpeg-min.sh
 
       - name: Build Rust workspace (release)
-        run: cargo build --release --features ffmpeg-static
+        run: cargo build --release
 
       - name: Build macOS app
         run: |

--- a/.github/workflows/macos-ui-ci.yml
+++ b/.github/workflows/macos-ui-ci.yml
@@ -60,11 +60,14 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install FFmpeg
-        run: brew install ffmpeg
+      - name: Install build dependencies
+        run: brew install nasm pkg-config
+
+      - name: Build trimmed FFmpeg bundle
+        run: ./scripts/build-ffmpeg-min.sh
 
       - name: Build Rust workspace (release)
-        run: cargo build --release
+        run: cargo build --release --features ffmpeg-static
 
       - name: Build macOS app
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: ./scripts/build-ffmpeg-min.sh
 
       - name: Build with static FFmpeg (debug)
-        run: cargo build -p subtitle-fast --features ffmpeg-static
+        run: cargo build -p subtitle-fast
 
       - name: Format check
         run: cargo fmt --all -- --check

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -59,24 +59,18 @@ jobs:
           sudo mkdir -p /var/cache/apt/archives
           sudo chown -R $USER:$USER /var/cache/apt/archives
 
-      - name: Cache FFmpeg apt packages
+      - name: Cache apt packages
         uses: actions/cache@v4
         with:
           path: /var/cache/apt/archives
-          key: rust-${{ runner.os }}-ffmpeg-apt-${{ hashFiles('.github/workflows/rust-ci.yml') }}
-          restore-keys: rust-${{ runner.os }}-ffmpeg-apt-
+          key: rust-${{ runner.os }}-apt-${{ hashFiles('.github/workflows/rust-ci.yml') }}
+          restore-keys: rust-${{ runner.os }}-apt-
 
-      - name: Install FFmpeg dependencies
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libavcodec-dev \
-            libavformat-dev \
-            libavutil-dev \
-            libavdevice-dev \
-            libavfilter-dev \
-            libswscale-dev \
-            libswresample-dev \
+            nasm \
             pkg-config
 
       - name: Prepare apt cache for saving
@@ -86,6 +80,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+
+      - name: Build trimmed FFmpeg bundle
+        run: ./scripts/build-ffmpeg-min.sh
+
+      - name: Build with static FFmpeg (debug)
+        run: cargo build -p subtitle-fast --features ffmpeg-static
 
       - name: Format check
         run: cargo fmt --all -- --check

--- a/crates/subtitle-fast-decoder/Cargo.toml
+++ b/crates/subtitle-fast-decoder/Cargo.toml
@@ -12,6 +12,12 @@ default = [
     "backend-dxva",
 ]
 backend-ffmpeg = ["dep:ffmpeg-next"]
+ffmpeg-static = [
+    "backend-ffmpeg",
+    "ffmpeg-next/static",
+    "ffmpeg-next/software-scaling",
+    "ffmpeg-next/software-resampling",
+]
 backend-videotoolbox = ["dep:mp4", "dep:rayon"]
 backend-mft = []
 backend-dxva = []
@@ -32,6 +38,7 @@ ffmpeg-next = { version = "8", optional = true, default-features = false, featur
     "codec",
     "format",
     "filter",
+    "software-scaling",
 ] }
 mp4 = { version = "0.14", optional = true }
 rayon = { version = "1.10", optional = true }

--- a/crates/subtitle-fast-decoder/Cargo.toml
+++ b/crates/subtitle-fast-decoder/Cargo.toml
@@ -12,12 +12,6 @@ default = [
     "backend-dxva",
 ]
 backend-ffmpeg = ["dep:ffmpeg-next"]
-ffmpeg-static = [
-    "backend-ffmpeg",
-    "ffmpeg-next/static",
-    "ffmpeg-next/software-scaling",
-    "ffmpeg-next/software-resampling",
-]
 backend-videotoolbox = ["dep:mp4", "dep:rayon"]
 backend-mft = []
 backend-dxva = []
@@ -39,6 +33,8 @@ ffmpeg-next = { version = "8", optional = true, default-features = false, featur
     "format",
     "filter",
     "software-scaling",
+    "software-resampling",
+    "static",
 ] }
 mp4 = { version = "0.14", optional = true }
 rayon = { version = "1.10", optional = true }

--- a/crates/subtitle-fast-decoder/README.md
+++ b/crates/subtitle-fast-decoder/README.md
@@ -28,10 +28,11 @@ When no feature is enabled, only the lightweight mock backend is compiled. GitHu
 so tests can exercise downstream logic without native dependencies.
 
 ### Static FFmpeg bundle (optional)
-- Run `scripts/build-ffmpeg-min.sh` to download and build a trimmed FFmpeg (H.264 decoder + `mov`/`matroska`/`mpegts` demuxers, `buffer`/`buffersink`/`format`/`scale` filters) as static libraries under `target/ffmpeg-min`. Override with `FFMPEG_VERSION`, `PREFIX`, or `BUILD_DIR` as needed.
+- Run `scripts/build-ffmpeg-min.sh` (Bash script) to download and build a trimmed FFmpeg (H.264 decoder + `mov`/`matroska`/`mpegts` demuxers, `buffer`/`buffersink`/`format`/`scale` filters) as static libraries under `target/ffmpeg-min`. Override with `FFMPEG_VERSION`, `PREFIX`, or `BUILD_DIR` as needed.
+- Windows (MSVC): open a Visual Studio Developer Command Prompt, start Git Bash from there so `cl` is on PATH, ensure GNU `make` (e.g., `mingw32-make`) plus `curl` and `nasm`/`yasm` are available, then run `FFMPEG_TOOLCHAIN=msvc MAKE=mingw32-make ./scripts/build-ffmpeg-min.sh` followed by `cargo build --release --features backend-ffmpeg,ffmpeg-static`.
 - `.cargo/config.toml` sets `FFMPEG_DIR=target/ffmpeg-min` (and `PKG_CONFIG_PATH` to the matching pkg-config dir) so `ffmpeg-sys-next` links the trimmed bundle when you build with `--features backend-ffmpeg,ffmpeg-static`.
 - If you prefer your own FFmpeg build, point `FFMPEG_DIR` (and `PKG_CONFIG_PATH`) to it before building to bypass the script output.
-- Prereqs: `curl`, `make`, `pkg-config`, and an assembler (`nasm` or `yasm`) available in `PATH`.
+- Prereqs: `curl`, `make`, and an assembler (`nasm` or `yasm`) available in `PATH`; `pkg-config` is helpful but not required when using `FFMPEG_DIR`.
 
 ## Configuration knobs
 

--- a/crates/subtitle-fast-decoder/README.md
+++ b/crates/subtitle-fast-decoder/README.md
@@ -27,6 +27,12 @@ compiled backend before surfacing the error.
 When no feature is enabled, only the lightweight mock backend is compiled. GitHub CI automatically enables the mock backend
 so tests can exercise downstream logic without native dependencies.
 
+### Static FFmpeg bundle (optional)
+- Run `scripts/build-ffmpeg-min.sh` to download and build a trimmed FFmpeg (H.264 decoder + `mov`/`matroska`/`mpegts` demuxers, `buffer`/`buffersink`/`format`/`scale` filters) as static libraries under `target/ffmpeg-min`. Override with `FFMPEG_VERSION`, `PREFIX`, or `BUILD_DIR` as needed.
+- `.cargo/config.toml` sets `FFMPEG_DIR=target/ffmpeg-min` (and `PKG_CONFIG_PATH` to the matching pkg-config dir) so `ffmpeg-sys-next` links the trimmed bundle when you build with `--features backend-ffmpeg,ffmpeg-static`.
+- If you prefer your own FFmpeg build, point `FFMPEG_DIR` (and `PKG_CONFIG_PATH`) to it before building to bypass the script output.
+- Prereqs: `curl`, `make`, `pkg-config`, and an assembler (`nasm` or `yasm`) available in `PATH`.
+
 ## Configuration knobs
 
 - Env vars: `SUBFAST_BACKEND`, `SUBFAST_INPUT`, and `SUBFAST_CHANNEL_CAPACITY` feed into `Configuration::from_env`.

--- a/crates/subtitle-fast-decoder/README.md
+++ b/crates/subtitle-fast-decoder/README.md
@@ -29,8 +29,8 @@ so tests can exercise downstream logic without native dependencies.
 
 ### Static FFmpeg bundle (optional)
 - Run `scripts/build-ffmpeg-min.sh` (Bash script) to download and build a trimmed FFmpeg (H.264 decoder + `mov`/`matroska`/`mpegts` demuxers, `buffer`/`buffersink`/`format`/`scale` filters) as static libraries under `target/ffmpeg-min`. Override with `FFMPEG_VERSION`, `PREFIX`, or `BUILD_DIR` as needed.
-- Windows (MSVC): open a Visual Studio Developer Command Prompt, start Git Bash from there so `cl` is on PATH, ensure GNU `make` (e.g., `mingw32-make`) plus `curl` and `nasm`/`yasm` are available, then run `FFMPEG_TOOLCHAIN=msvc MAKE=mingw32-make ./scripts/build-ffmpeg-min.sh` followed by `cargo build --release --features backend-ffmpeg,ffmpeg-static`.
-- `.cargo/config.toml` sets `FFMPEG_DIR=target/ffmpeg-min` (and `PKG_CONFIG_PATH` to the matching pkg-config dir) so `ffmpeg-sys-next` links the trimmed bundle when you build with `--features backend-ffmpeg,ffmpeg-static`.
+- Windows: build via MSYS2/MinGW (or similar) and run `./scripts/build-ffmpeg-min.sh`, then `cargo build --release --features backend-ffmpeg`.
+- `.cargo/config.toml` sets `FFMPEG_DIR=target/ffmpeg-min` (and `PKG_CONFIG_PATH` to the matching pkg-config dir) so `ffmpeg-sys-next` links the trimmed bundle automatically when you build with the FFmpeg backend enabled.
 - If you prefer your own FFmpeg build, point `FFMPEG_DIR` (and `PKG_CONFIG_PATH`) to it before building to bypass the script output.
 - Prereqs: `curl`, `make`, and an assembler (`nasm` or `yasm`) available in `PATH`; `pkg-config` is helpful but not required when using `FFMPEG_DIR`.
 

--- a/crates/subtitle-fast/Cargo.toml
+++ b/crates/subtitle-fast/Cargo.toml
@@ -16,7 +16,6 @@ default = ["detector-vision", "detector-parallel", "ocr-vision"]
 detector-vision = ["subtitle-fast-validator/detector-vision"]
 detector-parallel = ["subtitle-fast-validator/detector-parallel"]
 ocr-vision = ["subtitle-fast-ocr/engine-vision"]
-ffmpeg-static = ["subtitle-fast-decoder/ffmpeg-static"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/subtitle-fast/Cargo.toml
+++ b/crates/subtitle-fast/Cargo.toml
@@ -16,6 +16,7 @@ default = ["detector-vision", "detector-parallel", "ocr-vision"]
 detector-vision = ["subtitle-fast-validator/detector-vision"]
 detector-parallel = ["subtitle-fast-validator/detector-parallel"]
 ocr-vision = ["subtitle-fast-ocr/engine-vision"]
+ffmpeg-static = ["subtitle-fast-decoder/ffmpeg-static"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/scripts/build-ffmpeg-min.sh
+++ b/scripts/build-ffmpeg-min.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Build a trimmed static FFmpeg matching the decoder pipeline (H.264 decode + minimal demuxers/filters).
+# Outputs headers/libs under target/ffmpeg-min by default so FFMPEG_DIR in .cargo/config.toml can point there.
+# Env overrides:
+#   FFMPEG_VERSION   - FFmpeg release tag without leading "n" (default: 8.0.2)
+#   PREFIX           - install prefix (default: target/ffmpeg-min)
+#   BUILD_DIR        - work directory for sources/build (default: target/ffmpeg-build)
+#   JOBS             - parallel make jobs (default: detected cores)
+set -euo pipefail
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: missing dependency '$1'" >&2
+        exit 1
+    fi
+}
+
+detect_jobs() {
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+    elif command -v sysctl >/dev/null 2>&1; then
+        sysctl -n hw.ncpu 2>/dev/null || echo 4
+    else
+        echo 4
+    fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+require curl
+require tar
+require gzip
+require make
+require pkg-config
+
+FFMPEG_VERSION="${FFMPEG_VERSION:-8.0.1}"
+PREFIX="${PREFIX:-${ROOT_DIR}/target/ffmpeg-min}"
+BUILD_DIR="${BUILD_DIR:-${ROOT_DIR}/target/ffmpeg-build}"
+JOBS="${JOBS:-$(detect_jobs)}"
+
+TARBALL="${BUILD_DIR}/ffmpeg-${FFMPEG_VERSION}.tar.gz"
+SOURCE_DIR="${BUILD_DIR}/FFmpeg-n${FFMPEG_VERSION}"
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+echo "==> Fetching FFmpeg ${FFMPEG_VERSION}"
+if [ -f "${TARBALL}" ] && ! file "${TARBALL}" | grep -q "gzip compressed data"; then
+    echo "warning: ${TARBALL} is not an .tar.gz; re-downloading" >&2
+    rm -f "${TARBALL}"
+fi
+if [ ! -f "${TARBALL}" ]; then
+    curl -fL --retry 3 --retry-delay 1 --connect-timeout 15 \
+        "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n${FFMPEG_VERSION}.tar.gz" \
+        -o "${TARBALL}"
+fi
+
+rm -rf "${SOURCE_DIR}"
+tar -xzf "${TARBALL}"
+
+echo "==> Configuring (prefix=${PREFIX})"
+rm -rf "${PREFIX}"
+mkdir -p "${PREFIX}"
+pushd "${SOURCE_DIR}" >/dev/null
+
+./configure \
+    --prefix="${PREFIX}" \
+    --pkg-config-flags="--static" \
+    --enable-static \
+    --disable-shared \
+    --enable-pic \
+    --enable-small \
+    --disable-programs \
+    --disable-doc \
+    --disable-debug \
+    --disable-network \
+    --disable-autodetect \
+    --disable-everything \
+    --enable-protocol=file \
+    --enable-demuxer=mov \
+    --enable-demuxer=matroska \
+    --enable-demuxer=mpegts \
+    --enable-parser=h264 \
+    --enable-decoder=h264 \
+    --enable-swresample \
+    --enable-swscale \
+    --enable-avcodec \
+    --enable-avformat \
+    --enable-avfilter \
+    --enable-avutil \
+    --enable-filter=buffer \
+    --enable-filter=buffersink \
+    --enable-filter=format \
+    --enable-filter=scale \
+    --enable-pthreads \
+    --extra-cflags="-fPIC -O3" \
+    --extra-ldflags="-fPIC"
+
+echo "==> Building (jobs=${JOBS})"
+make -j "${JOBS}"
+echo "==> Installing to ${PREFIX}"
+make install
+popd >/dev/null
+
+cat <<EOF
+Done.
+Set env (already in .cargo/config.toml by default):
+  FFMPEG_DIR=${PREFIX}
+  PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
+Then build with:
+  cargo build -p subtitle-fast-decoder --features backend-ffmpeg,ffmpeg-static
+EOF

--- a/scripts/build-ffmpeg-min.sh
+++ b/scripts/build-ffmpeg-min.sh
@@ -147,5 +147,5 @@ Set env (already in .cargo/config.toml by default):
   FFMPEG_DIR=${PREFIX}
   PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
 Then build with:
-  cargo build -p subtitle-fast-decoder --features backend-ffmpeg,ffmpeg-static
+  cargo build -p subtitle-fast-decoder
 EOF

--- a/scripts/build-ffmpeg-min.sh
+++ b/scripts/build-ffmpeg-min.sh
@@ -10,7 +10,7 @@
 #   FFMPEG_ARCH      - arch used when FFMPEG_TOOLCHAIN=msvc (default: x86_64)
 #   FFMPEG_TARGET_OS - target os when FFMPEG_TOOLCHAIN=msvc (default: win64)
 #   MAKE             - make executable to run (default: make; for MSVC use a GNU make available in PATH)
-#   EXTRA_CFLAGS     - override extra cflags (default: -fPIC -O3, or /O2 for MSVC)
+#   EXTRA_CFLAGS     - override extra cflags (default: -fPIC -O3, or -O2 for MSVC)
 #   EXTRA_LDFLAGS    - override extra ldflags (default: -fPIC, or empty for MSVC)
 set -euo pipefail
 
@@ -60,7 +60,7 @@ EXTRA_LDFLAGS_DEFAULT="-fPIC"
 if [[ "${FFMPEG_TOOLCHAIN}" == "msvc" ]]; then
     THREAD_FLAG="--enable-w32threads"
     CONFIGURE_TOOLCHAIN=(--toolchain=msvc --arch="${FFMPEG_ARCH}" --target-os="${FFMPEG_TARGET_OS}")
-    EXTRA_CFLAGS_DEFAULT="/O2"
+    EXTRA_CFLAGS_DEFAULT="-O2"
     EXTRA_LDFLAGS_DEFAULT=""
 fi
 

--- a/ui-macos/scripts/make-dmg.sh
+++ b/ui-macos/scripts/make-dmg.sh
@@ -38,6 +38,15 @@ require_cmd() {
     fi
 }
 
+prepare_search_paths() {
+    # Ensure Xcode linker search paths exist to avoid warnings on single-arch builds.
+    mkdir -p \
+        "$ROOT/target/release" \
+        "$ROOT/target/aarch64-apple-darwin/release" \
+        "$ROOT/target/x86_64-apple-darwin/release" \
+        "$ROOT/target/universal/release"
+}
+
 target_triple() {
     case "$1" in
         arm64) echo "aarch64-apple-darwin" ;;
@@ -82,6 +91,7 @@ build_macos_app() {
     done
 
     log "Building macOS app (Release, ${archs[*]})"
+    prepare_search_paths
     xcodebuild \
         -project "$PROJECT" \
         -scheme "$SCHEME" \

--- a/ui-macos/subtitle-fast.xcodeproj/project.pbxproj
+++ b/ui-macos/subtitle-fast.xcodeproj/project.pbxproj
@@ -271,20 +271,14 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../target/release",
-					/opt/homebrew/lib,
-					/usr/local/lib,
+					"$(PROJECT_DIR)/../target/aarch64-apple-darwin/release",
+					"$(PROJECT_DIR)/../target/x86_64-apple-darwin/release",
+					"$(PROJECT_DIR)/../target/universal/release",
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsubtitle_fast",
-					"-lavcodec",
-					"-lavformat",
-					"-lavutil",
-					"-lswscale",
-					"-lswresample",
-					"-lavdevice",
-					"-lavfilter",
 					"-framework",
 					CoreMedia,
 					"-framework",
@@ -334,20 +328,14 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../target/release",
-					/opt/homebrew/lib,
-					/usr/local/lib,
+					"$(PROJECT_DIR)/../target/aarch64-apple-darwin/release",
+					"$(PROJECT_DIR)/../target/x86_64-apple-darwin/release",
+					"$(PROJECT_DIR)/../target/universal/release",
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsubtitle_fast",
-					"-lavcodec",
-					"-lavformat",
-					"-lavutil",
-					"-lswscale",
-					"-lswresample",
-					"-lavdevice",
-					"-lavfilter",
 					"-framework",
 					CoreMedia,
 					"-framework",


### PR DESCRIPTION
### 1. Minimal FFmpeg Build Script Added (`build-ffmpeg-min.sh`)

Introduces an automated script to download and build a minimized version of FFmpeg (H.264 decoder + required essentials only).
The script produces static libraries under `ffmpeg-min` and supports **macOS**, **Linux**, and **Windows (MSVC)**.

### 2. Simplified Build Configuration

Build setup is streamlined by configuring `FFMPEG_DIR` in `config.toml`, allowing `ffmpeg-sys-next` to automatically link against the static libraries.
The `ffmpeg-static` feature flag has been removed, making static linking the default behavior.

### 3. CI/CD Pipeline Updates

System-level FFmpeg dependencies are replaced with the new build script.
`nasm` and `pkg-config` are added as build dependencies, and overall build commands are simplified for a cleaner pipeline.

### 4. Improved macOS App Packaging

The `make-dmg.sh` script now supports static builds and includes a `--no-ffmpeg` option.
Dynamic FFmpeg library dependencies have been removed from the Xcode project.

### 5. Documentation Refresh

`README.md` has been updated with simplified build instructions and clearer guidance for Windows MSVC builds.
